### PR TITLE
- Fixed calling ant build on targets that have spaces in the name.

### DIFF
--- a/src/AntTargetRunner.js
+++ b/src/AntTargetRunner.js
@@ -70,7 +70,7 @@ module.exports = class AntTargetRunner {
       }
     }
 
-    this.antTerminal.sendText(`${this.antExecutable} ${target}`)
+    this.antTerminal.sendText(`${this.antExecutable} \"${target}\"`)
     this.antTerminal.show(true)
   }
 


### PR DESCRIPTION
Ex:<target name="My Build Target">